### PR TITLE
fix: fixed Dockerfile to compile project into .jar

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -1,5 +1,7 @@
 FROM amazoncorretto:21-al2-full
 
+RUN mvn compile && mvn clean package
+
 ADD /target/music_streaming_app-1.0-SNAPSHOT.jar back.jar
 
 ENTRYPOINT ["java", "-jar", "back.jar"]

--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -1,7 +1,14 @@
-FROM amazoncorretto:21-al2-full
+FROM maven:3-amazoncorretto-21 AS builder
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn clean package -DskipTests
 
-RUN mvn compile && mvn clean package
+FROM amazoncorretto:21-al2-full as final
+WORKDIR /app
+COPY --from=builder /app/target/music_streaming_app-1.0-SNAPSHOT.jar back.jar
 
-ADD /target/music_streaming_app-1.0-SNAPSHOT.jar back.jar
+CMD ["java", "-jar", "back.jar"]
 
-ENTRYPOINT ["java", "-jar", "back.jar"]
+
+


### PR DESCRIPTION
Fixed problem that Dockerfile wasn't compiling a project into .jar file by itself. Now it compiles the project automatically and a docker container starts without problems.  